### PR TITLE
update_do_droplet

### DIFF
--- a/ansible_tasks/update_do_droplets/README.md
+++ b/ansible_tasks/update_do_droplets/README.md
@@ -2,7 +2,7 @@
 Install Tugboat, the command-line interface to DigitalOcean https://github.com/pearkes/tugboat
 
 # Inventory
-Use `cerae_inventory.sh` makes use of tugboat to generate an inventory of IPs of all your DO droplets to be used with the Ansible playbook included in this project.
+Use `create_inventory.sh` to generate (via Tugboat) an inventory of IPs of all your DO droplets to be used with the Ansible playbook included in this project.
 
 The Ansible playbook installs the `DO-Agent` in all the droplets of inventory given that you connect as root or that your use has sudo capabilities.
 

--- a/ansible_tasks/update_do_droplets/README.md
+++ b/ansible_tasks/update_do_droplets/README.md
@@ -1,0 +1,12 @@
+# Requirements
+Install Tugboat, the command-line interface to DigitalOcean https://github.com/pearkes/tugboat
+
+# Inventory
+Use `cerae_inventory.sh` makes use of tugboat to generate an inventory of IPs of all your DO droplets to be used with the Ansible playbook included in this project.
+
+The Ansible playbook installs the `DO-Agent` in all the droplets of inventory given that you connect as root or that your use has sudo capabilities.
+
+The playbook can be extended to run more operations on the droplets
+
+# command to run, will ask for sudo_password
+ansible-playbook playbook.yml -i inventory  --ssh-extra-args='-o StrictHostKeyChecking=no' -K

--- a/ansible_tasks/update_do_droplets/create_inventory.sh
+++ b/ansible_tasks/update_do_droplets/create_inventory.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+INVENTORY_FILE="inventory"
+echo "[droplets]" > $INVENTORY_FILE
+tugboat droplets | cut -d':' -f2  | cut -d',' -f1  >> $INVENTORY_FILE

--- a/ansible_tasks/update_do_droplets/playbook.yml
+++ b/ansible_tasks/update_do_droplets/playbook.yml
@@ -1,0 +1,13 @@
+---
+- hosts: droplets
+  gather_facts: false
+  tasks:
+  - name: Update DO-Agent
+    shell: >
+            curl -sSL https://agent.digitalocean.com/install.sh | sh
+
+    become: true
+    # notify:
+    #   - restart JumpCloud
+
+...


### PR DESCRIPTION
A simple Ansible playbook to install `DO-Agent` on a group of droplets
accompanied by  bash script to generate an inventory of all the droplets of a DigitalOcean account via Tugboat command-line tool